### PR TITLE
Make the dialog lock to the center

### DIFF
--- a/nautilus-create-new-file.py
+++ b/nautilus-create-new-file.py
@@ -76,7 +76,7 @@ class CreateFileExtension(GObject.GObject, Nautilus.MenuProvider):
         )
         menu_item.connect(
             "activate",
-            lambda *_: CreateFileDialog(folder).present(None),
+            lambda *_: CreateFileDialog(folder).present(Gtk.Application.get_default().get_active_window()),
             None,
         )
         return [


### PR DESCRIPTION
Slight tweak that makes the dialog stick to the center of the nautilus window and greys out the nautilus window while it's open. This matches the "Create new folder" dialog.

Once again, this was generated using cgpt but it works, so please check if it's the right way to do it.